### PR TITLE
Add Python3.x support and some unittests

### DIFF
--- a/beer.py
+++ b/beer.py
@@ -1,13 +1,12 @@
-for quant in range(99, 0, -1):
-    if quant > 1:
-        print quant, "bottles of beer on the weall.", quant, 'bottles of beer.'
-        if quant > 2:
-            suffix = str(quant - 1) + "bottles of beer on the wall"
-        else:
-            suffix = "1 bottle of beer on the wall."
-    elif quant == 1:
-        print "1 bottle of beer on the wall"
-        suffix = 'no more beer on the wall!'
+pluralize = lambda x: x != 1 and 's' or ''
+bottle_beer = lambda x: "{} bottle{} of beer".format(x, pluralize(x))
 
-    print "take one down, pass it around,", suffix
-    print '--'
+def _beer_printer(quant):
+    print("{b} on the wall. {b}.".format(b=bottle_beer(quant)))
+    next_up = "{} on the wall.\n--".format(bottle_beer(quant - 1))
+    if quant - 1 <= 0:
+        next_up = "no more bottles of beer on the wall."
+    print("Take one down, pass it around, {}".format(next_up))
+
+if __name__ == "__main__":
+    list(map(lambda quant: _beer_printer(quant), range(99, 0, -1)))

--- a/test_beer.py
+++ b/test_beer.py
@@ -1,0 +1,70 @@
+from contextlib import contextmanager
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    # This is neccessary for Python 3.x which moves StringIO into io.
+    from io import StringIO
+
+import unittest, sys
+
+from beer import pluralize, bottle_beer, _beer_printer
+
+
+@contextmanager
+def captured_output():
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+
+class TestBeer(unittest.TestCase):
+    def test_pluralize(self):
+        self.assertEqual(pluralize(100**100), 's')
+        self.assertEqual(pluralize(2), 's')
+        self.assertEqual(pluralize(1), '')
+        self.assertEqual(pluralize(0), 's')
+        self.assertEqual(pluralize(-1), 's')
+
+    def test_bottle_beer(self):
+        self.assertEqual(bottle_beer(100), '100 bottles of beer')
+        self.assertEqual(bottle_beer(2), '2 bottles of beer')
+        self.assertEqual(bottle_beer(1), '1 bottle of beer')
+        self.assertEqual(bottle_beer(0), '0 bottles of beer')
+        self.assertEqual(bottle_beer(-1), '-1 bottles of beer')
+
+    def test_beer_printer_with_100_beers(self):
+        expected = ('100 bottles of beer on the wall. 100 bottles of beer.\n'
+                    'Take one down, pass it around, 99 bottles of beer on the wall.\n--')
+        with captured_output() as (out, err):
+            _beer_printer(100)
+            self.assertEqual(out.getvalue().strip(), expected)
+
+    def test_beer_printer_with_2_beers(self):
+        expected = ('2 bottles of beer on the wall. 2 bottles of beer.\n'
+                    'Take one down, pass it around, 1 bottle of beer on the wall.\n--')
+        with captured_output() as (out, err):
+            _beer_printer(2)
+            self.assertEqual(out.getvalue().strip(), expected)
+
+    def test_beer_printer_with_1_beer(self):
+        expected = ('1 bottle of beer on the wall. 1 bottle of beer.\n'
+                    'Take one down, pass it around, no more bottles of beer on the wall.')
+        with captured_output() as (out, err):
+            _beer_printer(1)
+            self.assertEqual(out.getvalue().strip(), expected)
+
+    def test_beer_printer_with_0_beers(self):
+        expected = ('0 bottles of beer on the wall. 0 bottles of beer.\n'
+                    'Take one down, pass it around, no more bottles of beer on the wall.')
+        with captured_output() as (out, err):
+            _beer_printer(0)
+            self.assertEqual(out.getvalue().strip(), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds support for Python 3.x and includes some tests to make sure everything is working properly.

###### PYTHON 2.x

```
beers-on-the-wall git:py3k-support-and-tests ❯ python2 test_beer.py -v
test_beer_printer_with_0_beers (__main__.TestBeer) ... ok
test_beer_printer_with_100_beers (__main__.TestBeer) ... ok
test_beer_printer_with_1_beer (__main__.TestBeer) ... ok
test_beer_printer_with_2_beers (__main__.TestBeer) ... ok
test_bottle_beer (__main__.TestBeer) ... ok
test_pluralize (__main__.TestBeer) ... ok

----------------------------------------------------------------------
Ran 6 tests in 0.001s

OK
```

###### PYTHON 3.x

```
beers-on-the-wall git:py3k-support-and-tests ❯ python3 test_beer.py -v
test_beer_printer_with_0_beers (__main__.TestBeer) ... ok
test_beer_printer_with_100_beers (__main__.TestBeer) ... ok
test_beer_printer_with_1_beer (__main__.TestBeer) ... ok
test_beer_printer_with_2_beers (__main__.TestBeer) ... ok
test_bottle_beer (__main__.TestBeer) ... ok
test_pluralize (__main__.TestBeer) ... ok

----------------------------------------------------------------------
Ran 6 tests in 0.001s

OK
```